### PR TITLE
Sane default length units. Other standard updates.

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -42,12 +42,12 @@ return array(
 		'area' => array(
 
 			'sqm' => array(
-				'format' => '1,00.00 SQM',
+				'format' => '1,00.00 sq m',
 				'unit'   => 1,
 			),
 
 			'acre' => array(
-				'format' => '1,00.000 Acres',
+				'format' => '1,00.000 ac',
 				'unit'   => 0.000247105,
 			),
 
@@ -90,23 +90,38 @@ return array(
 		'length' => array(
 
 			'km' => array(
-				'format' => '1,0.00 KM',
-				'unit'   => 1.00,
+				'format' => '1,0.000 km',
+				'unit'   => 0.001,
+			),
+
+			'mi' => array(
+				'format' => '1,0.000 mi.',
+				'unit'   => 0.000621371,
 			),
 
 			'm' => array(
-				'format' => '1,0.00 M',
-				'unit'   => 1000,
+				'format' => '1,0.000 m',
+				'unit' => 1.00,
 			),
 
 			'cm' => array(
-				'format' => '1,0.00 CM',
-				'unit'   => 100000,
+				'format' => '1!0 cm',
+				'unit'   => 100,
 			),
 
 			'mm' => array(
-				'format' => '1,0.00 MM',
-				'unit'   => 1000000,
+				'format' => '1,0.00 mm',
+				'unit'   => 1000,
+			),
+
+			'ft' => array(
+				'format' => '1,0.00 ft.',
+				'unit'   => 3.28084,
+			),
+
+			'in' => array(
+				'format' => '1,0.00 in.',
+				'unit'   => 39.3701,
 			),
 
 		),
@@ -123,12 +138,12 @@ return array(
 		'weight' => array(
 
 			'kg' => array(
-				'format' => '1,0.00 KG',
+				'format' => '1,0.00 kg',
 				'unit'   => 1.00,
 			),
 
 			'g' => array(
-				'format' => '1,0.00 G',
+				'format' => '1,0.00 g',
 				'unit'   => 1000.00,
 			),
 

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -87,27 +87,37 @@ class ConverterTest extends PHPUnit_Framework_TestCase {
 
 				'km' => array(
 					'format' => '1,0.000 KM',
-					'unit'   => 1.00,
+					'unit'   => 0.001,
 				),
 
 				'mile' => array(
 					'format' => '1,0.000 Miles',
-					'unit'   => 0.621371,
+					'unit'   => 0.000621371,
+				),
+
+				'meter' => array(
+					'format' => '1,0.000',
+					'unit' => 1.00,
 				),
 
 				'cm' => array(
 					'format' => '1!0 centimeters',
-					'unit'   => 100000
+					'unit'   => 100
 				),
 
 				'mm' => array(
 					'format' => '1,0.00 millimeters',
-					'unit'   => 1000000
+					'unit'   => 1000
 				),
 
 				'ft' => array(
 					'format' => '1,0.00 feet',
-					'unit'   => 3280.84
+					'unit'   => 3.28084
+				),
+
+				'in' => array(
+					'format' => '1,0.00 inches',
+					'unit'   => 39.3701
 				),
 
 			),
@@ -300,6 +310,20 @@ class ConverterTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($ftCm->format(), '6096 centimeters');
 
 		$this->assertEquals(round($ftCm->getValue(), 3), 6096);
+
+		// Meter to Feet
+		$meterFt = $this->converter->from('length.meter')->to('length.ft')->convert(200);
+
+		$this->assertEquals($meterFt->format(), '656.17 feet');
+
+		$this->assertEquals(round($meterFt->getValue(), 3), 656.168);
+
+		// Meter to inches
+		$meterIn = $this->converter->from('length.meter')->to('length.in')->convert(200);
+
+		$this->assertEquals($meterIn->format(), '7,874.02 inches');
+
+		$this->assertEquals(round($meterIn->getValue(), 3), 7874.02);
 	}
 
 	/**


### PR DESCRIPTION
This is the PR against master as discussed in issue #3.

---

Updated test use meter as the base for length tests. Added a few extra tests in to help cover the modification. Also updated the base config to reflect the base unit change and added a few common imperial units. Config also updated to have formats use abbreviations inline with the International System of Units.
