### PR TITLE
Create fallback cache storage for currencies in the event of the open…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ We do not give estimated times for completion on `Accepted` Proposals.
 
 ---
 
+#### v2.0.4 - 2017-06-29
+
+`FIXED`
+
+- Openexchange API error now uses a backup cached version of the currency rates previously collected.
+
 #### v2.0.3 - 2015-12-18
 
 `FIXED`

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/src/Exchangers/ExchangerInterface.php
+++ b/src/Exchangers/ExchangerInterface.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/src/Exchangers/NativeExchanger.php
+++ b/src/Exchangers/NativeExchanger.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/src/Laravel/ConverterServiceProvider.php
+++ b/src/Laravel/ConverterServiceProvider.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/src/Laravel/Facades/Converter.php
+++ b/src/Laravel/Facades/Converter.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -11,7 +11,7 @@
  * bundled with this package in the LICENSE file.
  *
  * @package    Converter
- * @version    2.0.3
+ * @version    2.0.4
  * @author     Cartalyst LLC
  * @license    BSD License (3-clause)
  * @copyright  (c) 2011-2016, Cartalyst LLC


### PR DESCRIPTION
…exchange api call failing. Also fall back to default values in the event of the api call failing at the same time as the cache fallback being empty. This prevents constant api calls in an application

Signed-off-by: Ben James <in@benjam.es>